### PR TITLE
[Replace pip3 with pipx for package installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ docker compose up -d --build
 ### Without Docker
 Dependencies:
 ```bash
-python3 -m pip install --user pip3
-pip3 install pdm
+python3 -m pip install --user pipx
+pipx install pdm
 pdm install --no-self
 ```
 


### PR DESCRIPTION
[Replace pip3 with pipx for package installations](https://github.com/mjanez/ckan-mqa/commit/d0451fd85d697654a8e401edbbd6d98f57356565) 

Using pipx allows us to install Python applications in isolated environments, which helps to avoid dependency conflicts. This change enhances the robustness of our Python environment setup and makes it easier to manage Python applications and their dependencies.